### PR TITLE
Remove log link

### DIFF
--- a/run.go
+++ b/run.go
@@ -23,7 +23,6 @@ func Run(f func(ctx context.Context) error) {
 	ctx := trap.Context()
 
 	// Handle uncaught panics.
-	errMsg := fmt.Sprintf("View the task logs for details: app.airplane.dev/runs/%s", os.Getenv("AIRPLANE_RUN_ID"))
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Fprintf(os.Stderr, "%+v\n", r)
@@ -32,7 +31,6 @@ func Run(f func(ctx context.Context) error) {
 			} else {
 				MustNamedOutput("error", fmt.Sprintf("%s", r))
 			}
-			MustNamedOutput("error", errMsg)
 			os.Exit(1)
 		}
 	}()
@@ -40,7 +38,6 @@ func Run(f func(ctx context.Context) error) {
 	if err := f(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		MustNamedOutput("error", err.Error())
-		MustNamedOutput("error", errMsg)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Since we show a logs tab in the sessions UI now, we no longer need to include a link in the output:

![image](https://user-images.githubusercontent.com/2907397/136468420-79844c74-6045-4797-9310-f3909e0bc7ef.png)

Will release as `0.1.1`.