### PR TITLE
Add debug.Stack() to panic logs

### DIFF
--- a/run.go
+++ b/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"time"
 
 	// TODO: move this into a separate Go package.
@@ -25,7 +26,7 @@ func Run(f func(ctx context.Context) error) {
 	// Handle uncaught panics.
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Fprintf(os.Stderr, "%+v\n", r)
+			fmt.Fprintf(os.Stderr, "%+v\n%s\n", r, debug.Stack())
 			if err, ok := r.(error); ok {
 				MustSetOutput(err.Error(), "error")
 			} else {


### PR DESCRIPTION
I encountered this while trying to debug a panic. Having the stacktrace
would make it much easier to pin down where the panic is happening.
